### PR TITLE
Fix normalization bug for numeric queries

### DIFF
--- a/fl_rank/service/ranking_service.py
+++ b/fl_rank/service/ranking_service.py
@@ -448,5 +448,9 @@ class RankingService:
         # Ensure vector is properly shaped
         if len(query_vector.shape) == 1:
             query_vector = query_vector.reshape(1, -1)
-        
+
+        # Normalize numeric query vectors if required
+        if self.normalize_vectors:
+            query_vector = normalize_vectors(query_vector)
+
         return query_vector


### PR DESCRIPTION
## Summary
- ensure numeric query vectors are normalized

## Testing
- `python - <<'PY'
from fl_rank.service.ranking_service import RankingService

service = RankingService()
items=[{'id':'1','content':['python','machine learning']},{'id':'2','content':['java','backend']},{'id':'3','content':['javascript','frontend']}]
service.add_items(items, id_field='id', content_field='content')
print(service.find_similar(['python'],k=2))
vec = [0.1]*service.embedding_model.get_dimension()
print(service.find_similar(vec,k=1))
PY`